### PR TITLE
Fix palette reference

### DIFF
--- a/vizta/palettes.py
+++ b/vizta/palettes.py
@@ -1,5 +1,5 @@
 """Plotting color palettes"""
-import seaborn as sns
+from seaborn import palettes
 
 # Add new color palettes here:
 VIZTA_PALETTES = {
@@ -9,4 +9,4 @@ VIZTA_PALETTES = {
 
 # Register palettes:
 for name, colors in VIZTA_PALETTES.items():
-    sns.palettes.SEABORN_PALETTES[name] = colors
+    palettes.SEABORN_PALETTES[name] = colors


### PR DESCRIPTION
This PR fixes how vizta registers palettes for compatibility with newer versions of Seaborn.